### PR TITLE
Remove Internal State from LazyText

### DIFF
--- a/Sources/CardinalKitViews/Text/LazyText.swift
+++ b/Sources/CardinalKitViews/Text/LazyText.swift
@@ -14,23 +14,23 @@ import SwiftUI
 /// Uses a `LazyVStack` under the hood to load and display the text line-by-line.
 public struct LazyText: View {
     private let text: String
-    @State private var lines: [(linenumber: Int, text: String)] = []
     
+    
+    private var lines: [(id: UUID, text: String)] {
+        var lines: [(id: UUID, text: String)] = []
+        text.enumerateLines { line, _ in
+            lines.append((UUID(), line))
+        }
+        return lines
+    }
     
     public var body: some View {
         LazyVStack(alignment: .leading) {
-            ForEach(lines, id: \.linenumber) { line in
+            ForEach(lines, id: \.id) { line in
                 Text(line.text)
                     .multilineTextAlignment(.leading)
             }
         }
-            .onAppear {
-                var lineNumber = 0
-                text.enumerateLines { line, _ in
-                    lines.append((lineNumber, line))
-                    lineNumber += 1
-                }
-            }
     }
     
     


### PR DESCRIPTION
# Remove Internal State from LazyText

## :recycle: Current situation & Problem
- The current implementation of LazyText keeps an internal state based on the input that is not updated when a view is redrawn based on changes on the surrounding view comments.

## :bulb: Proposed solution
- This PR removes the internal state and improves the line handling by referencing lines by unique identifiers instead of numbers, forcing a redraw of all lines if the text changes.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

